### PR TITLE
CXJ1-2928 & CXJ1-2754 -> FEDEV-3558-3559-3560 (Adding new query string hostName & siteId into VerifyLoginSession API)

### DIFF
--- a/mobile/src/index.js
+++ b/mobile/src/index.js
@@ -19,6 +19,7 @@ class Nevis extends React.Component {
             qrCodeImg: '', // QR code image
             enabledNevis: false,
             showUnableModal: false,
+            hostEnd: '',
         };
 
         const { showNevis = false } = props;
@@ -27,6 +28,13 @@ class Nevis extends React.Component {
         }
 
         this.config = getConfig();
+    }
+
+    componentDidMount() {
+        if (typeof window !== 'undefined') {
+            const hostEnd = `${window.location.protocol}//${window.location.host}/`;
+            this.setState({ hostEnd });
+        }
     }
 
     componentDidUpdate(prevProps) {
@@ -184,6 +192,7 @@ class Nevis extends React.Component {
 
     verifyLoginSession = (statusToken) => {
         const { post } = getConfig();
+        const {hostEnd} = this.state;
 
         // Track whether a request is pending
         let isRequestPending = false;  // Add a flag to track pending requests
@@ -210,8 +219,7 @@ class Nevis extends React.Component {
 
             // Set the flag to indicate the request is pending
             isRequestPending = true;
-    
-            post(ApiLink.VerifyLoginSession + `statusToken=${statusToken}&`)
+            post(ApiLink.VerifyLoginSession + `statusToken=${statusToken}&hostName=${hostEnd}&`)
                 .then((res) => {
                     if (res?.isSuccess) {
                         clearInterval(this.verificationInterval);  // Clear the interval after successful

--- a/mobile/src/index.js
+++ b/mobile/src/index.js
@@ -219,7 +219,7 @@ class Nevis extends React.Component {
 
             // Set the flag to indicate the request is pending
             isRequestPending = true;
-            post(ApiLink.VerifyLoginSession + `statusToken=${statusToken}&hostName=${hostEnd}&`)
+            post(ApiLink.VerifyLoginSession + `statusToken=${statusToken}&hostName=${hostEnd}&siteId=2&`)
                 .then((res) => {
                     if (res?.isSuccess) {
                         clearInterval(this.verificationInterval);  // Clear the interval after successful


### PR DESCRIPTION
## JIRA票號
[CXJ1-2928](https://arcadie.atlassian.net/browse/CXJ1-2928)
[CXJ1-2754](https://arcadie.atlassian.net/browse/CXJ1-2954)

## 請條列修改重點
- 針對 /api/Auth/PasswordlessAuthentication/VerifyLoginSession 前端新增選擇性傳參 siteId 
- 針對 /api/Auth/PasswordlessAuthentication/VerifyLoginSession 前端新增傳遞 query string hostName

## 提交PR前請檢查以下是否已完成：
- [x] 已合併master最新代碼
- [x] 已自行檢查過大小寫、註釋、引用正確
- [x] PR 有明確標題、內容描述與commit
- [x] 已留意這張PR代碼變更未超過150-180行(asset增加不算)
